### PR TITLE
patching PDFCore.py to properly check for ids in self.objects

### DIFF
--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -4322,25 +4322,17 @@ class PDFBody:
                                 self.setObject(compressedId, compressedObject, offset)
                             del(compressedObjectsDict)
         for id in self.referencedJSObjects:
-            if id not in self.containingJS:
-                if self.objects:
-                    if str(id) in self.objects:
-                        errorMessage = 'Object is None'
-                        if isForceMode:
-                            pdfFile.addError(errorMessage)
-                            continue
-                else:
-                    object = self.objects[str(id)].getObject()
-                    if object:
-                        errorMessage = 'Object is None'
-                        if isForceMode:
-                            pdfFile.addError("TEST")
-                            pdfFile.addError(errorMessage)
-                            continue
-                        else:
-                            return (-1, errorMessage)
-                    object.setReferencedJSObject(True)
-                    self.updateStats(id, object)
+            if id not in self.containingJS and id in self.objects:
+                object = self.objects[id].getObject()
+                if object is None:
+                    errorMessage = 'Object is None'
+                    if isForceMode:
+                        pdfFile.addError(errorMessage)
+                        continue
+                    else:
+                        return (-1, errorMessage)
+                object.setReferencedJSObject(True)
+                self.updateStats(id, object)
         if errorMessage != '':
             return (-1, errorMessage)
         return (0, '')

--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -4323,16 +4323,24 @@ class PDFBody:
                             del(compressedObjectsDict)
         for id in self.referencedJSObjects:
             if id not in self.containingJS:
-                object = self.objects[id].getObject()
-                if object is None:
-                    errorMessage = 'Object is None'
-                    if isForceMode:
-                        pdfFile.addError(errorMessage)
-                        continue
-                    else:
-                        return (-1, errorMessage)
-                object.setReferencedJSObject(True)
-                self.updateStats(id, object)
+                if self.objects:
+                    if str(id) in self.objects:
+                        errorMessage = 'Object is None'
+                        if isForceMode:
+                            pdfFile.addError(errorMessage)
+                            continue
+                else:
+                    object = self.objects[str(id)].getObject()
+                    if object:
+                        errorMessage = 'Object is None'
+                        if isForceMode:
+                            pdfFile.addError("TEST")
+                            pdfFile.addError(errorMessage)
+                            continue
+                        else:
+                            return (-1, errorMessage)
+                    object.setReferencedJSObject(True)
+                    self.updateStats(id, object)
         if errorMessage != '':
             return (-1, errorMessage)
         return (0, '')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="peepdf",
-    version="0.4.1",
+    version="0.4.2",
     author="Jose Miguel Esparza",
     license="GNU GPLv3",
     url="http://eternal-todo.com",


### PR DESCRIPTION
So I ran into a bug with the following pdf md5:bd23ad33accef14684d42c32769092a0
this would cause peepdf to break with the following error
```Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/peepdf/main.py", line 409, in main
    ret, pdf = pdfParser.parse(fileName, options.isForceMode, options.isLooseMode, options.isManualAnalysis)
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 7116, in parse
    ret = body.updateObjects()
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 4326, in updateObjects
    object = self.objects[id].getObject()
KeyError: 1
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/peepdf/main.py", line 409, in main
    ret, pdf = pdfParser.parse(fileName, options.isForceMode, options.isLooseMode, options.isManualAnalysis)
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 7122, in parse
    ret = body.updateObjects()
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 4326, in updateObjects
    if self.objects[str(id)]:
KeyError: '1'
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/peepdf/main.py", line 409, in main
    ret, pdf = pdfParser.parse(fileName, options.isForceMode, options.isLooseMode, options.isManualAnalysis)
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 7123, in parse
    ret = body.updateObjects()
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 4326, in updateObjects
    if self.objects[str(id)]:
KeyError: '1'
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/peepdf/main.py", line 409, in main
    ret, pdf = pdfParser.parse(fileName, options.isForceMode, options.isLooseMode, options.isManualAnalysis)
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 7124, in parse
    ret = body.updateObjects()
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 4326, in updateObjects
    if self.objects[str(id)]:
KeyError: '1'
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/peepdf/main.py", line 409, in main
    ret, pdf = pdfParser.parse(fileName, options.isForceMode, options.isLooseMode, options.isManualAnalysis)
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 7126, in parse
    ret = body.updateObjects()
  File "build/bdist.linux-x86_64/egg/peepdf/PDFCore.py", line 4327, in updateObjects
    if self.objects[id]:
KeyError: 1
```
This patch makes it so it doesn't hard break and does a better check for the ID in self.object so it doesn't totally break trying to set the value as None.

After fix output is as follows
```
File: 1.pdf
MD5: bd23ad33accef14684d42c32769092a0
SHA1: 0d3f335ccca4575593054446f5f219eba6cd93fe
SHA256: 4b672deae5c1231ea20ea70b0bf091164ef0b939e2cf4d142d31916a169e8e01
Size: 82344 bytes
Version: 1.7
Binary: False
Linearized: True
Encrypted: False
Updates: 0
Objects: 50
Streams: 14
URIs: 0
Comments: 0
Errors: 0

Version 0:
        Catalog: 10
        Info: No
        Objects (50): [6, 7, 9, 10, 11, 12, 14, 15, 17, 19, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 40, 41, 42, 43, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 61, 62, 63, 64, 65, 66]
                Errors (11): [14, 15, 17, 25, 31, 32, 33, 49, 51, 55, 56]
        Streams (14): [14, 15, 17, 25, 31, 32, 33, 34, 49, 51, 55, 56, 57, 62]
                Encoded (11): [14, 15, 17, 25, 31, 32, 33, 49, 51, 55, 56]
                Decoding errors (11): [14, 15, 17, 25, 31, 32, 33, 49, 51, 55, 56]
        Suspicious elements:
                /AcroForm (1): [10]
                /OpenAction (1): [10]
                /JS (1): [11]
                /JavaScript (1): [11]
```