### PR TITLE
Fix object stream parsing

### DIFF
--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -7857,6 +7857,11 @@ class PDFParser:
         pdfObject = None
         oldCounter = self.charCounter
         self.charCounter = 0
+        # skip leading whitespace in case of sloppy reference offsets
+        self.readSpaces(content)
+        if self.charCounter > 0:
+            content = content[self.charCounter:]
+            self.charCounter = 0
         if objectType is not None:
             objectsTypeArray = [self.delimiters[i][2] for i in range(len(self.delimiters))]
             index = objectsTypeArray.index(objectType)
@@ -8011,7 +8016,6 @@ class PDFParser:
             errorMessage = 'EOF while looking for symbol "'+symbol+'"'
             pdfFile.addError(errorMessage)
             return (-1, errorMessage)
-        self.readSpaces(string)
         while string[self.charCounter] == '%':
             ret = self.readUntilEndOfLine(string)
             if ret[0] == -1:

--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -1217,6 +1217,14 @@ class PDFArray(PDFObject):
         ret = self.update()
         return ret
 
+    def getJSCode(self):
+        '''
+            Gets the Javascript code of the object
+
+            @return: An array of Javascript code sections
+        '''
+        return self.JSCode
+
 
 class PDFDictionary(PDFObject):
     def __init__(self, rawContent='', elements={}, rawNames={}):

--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -3000,29 +3000,31 @@ class PDFObjectStream (PDFStream):
                                     if self.isEncodedStream:
                                         self.decode()
                                 self.size = len(self.rawStream)
-                        offsetsSection = self.decodedStream[:self.firstObjectOffset]
-                        objectsSection = self.decodedStream[self.firstObjectOffset:]
-                        numbers = re.findall('\d{1,10}', offsetsSection)
-                        if numbers != [] and len(numbers) % 2 == 0:
-                            for i in range(0, len(numbers), 2):
-                                id = int(numbers[i])
-                                offset = int(numbers[i+1])
-                                ret = PDFParser().readObject(objectsSection[offset:])
-                                if ret[0] == -1:
-                                    if isForceMode:
-                                        object = None
-                                        self.addError(ret[1])
+
+                        if not self.updateNeeded:
+                            offsetsSection = self.decodedStream[:self.firstObjectOffset]
+                            objectsSection = self.decodedStream[self.firstObjectOffset:]
+                            numbers = re.findall('\d{1,10}', offsetsSection)
+                            if numbers != [] and len(numbers) % 2 == 0:
+                                for i in range(0, len(numbers), 2):
+                                    id = int(numbers[i])
+                                    offset = int(numbers[i+1])
+                                    ret = PDFParser().readObject(objectsSection[offset:])
+                                    if ret[0] == -1:
+                                        if isForceMode:
+                                            object = None
+                                            self.addError(ret[1])
+                                        else:
+                                            return ret
                                     else:
-                                        return ret
-                                else:
-                                    object = ret[1]
-                                self.compressedObjectsDict[id] = [offset, object]
-                                self.indexes.append(id)
-                        else:
-                            if isForceMode:
-                                self.addError('Missing offsets in object stream')
+                                        object = ret[1]
+                                    self.compressedObjectsDict[id] = [offset, object]
+                                    self.indexes.append(id)
                             else:
-                                return (-1, 'Missing offsets in object stream')
+                                if isForceMode:
+                                    self.addError('Missing offsets in object stream')
+                                else:
+                                    return (-1, 'Missing offsets in object stream')
                     elif modifiedCompressedObjects:
                         tmpStreamObjects = ''
                         tmpStreamObjectsInfo = ''

--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -8003,6 +8003,7 @@ class PDFParser:
             errorMessage = 'EOF while looking for symbol "'+symbol+'"'
             pdfFile.addError(errorMessage)
             return (-1, errorMessage)
+        self.readSpaces(string)
         while string[self.charCounter] == '%':
             ret = self.readUntilEndOfLine(string)
             if ret[0] == -1:

--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -8153,7 +8153,6 @@ class PDFParser:
 
         newString = string[self.charCounter:]
 
-        self.charCounter = 0
         index = newString.find(symbol)
         if index == -1:
             errorMessage = 'Symbol "'+symbol+'" not found'

--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -3251,8 +3251,9 @@ class PDFObjectStream (PDFStream):
                 numbers = re.findall('\d{1,10}', offsetsSection)
                 if numbers != [] and len(numbers) % 2 == 0:
                     for i in range(0, len(numbers), 2):
-                        offset = numbers[i+1]
-                        ret = PDFParser.readObject(objectsSection[offset:])
+                        id = int(numbers[i])
+                        offset = int(numbers[i+1])
+                        ret = PDFParser().readObject(objectsSection[offset:])
                         if ret[0] == -1:
                             if isForceMode:
                                 object = None
@@ -3261,7 +3262,8 @@ class PDFObjectStream (PDFStream):
                                 return ret
                         else:
                             object = ret[1]
-                        self.compressedObjectsDict[numbers[i]] = [offset, object]
+                        self.compressedObjectsDict[id] = [offset, object]
+                        self.indexes.append(id)
                 else:
                     errorMessage = 'Missing offsets in object stream'
                     if isForceMode:


### PR DESCRIPTION
Commit 8cc27b6a broke object stream parsing by resetting the content
cursor `PDFParser.charCounter` to zero on every invocation. Unfortunately it's unclear from the change what this was fixing at the time but it certainly broke object stream parsing. Reproducer:
``` shell
$ echo -e "create pdf\ncreate object_stream\nall\nsave /tmp/foo.pdf" | \
	peepdf -i
```
Without fix:
``` shell
$ peepdf -j /tmp/foo.pdf
Error: An error has occurred while parsing an indirect object!!
```
With this change: JSON output as expected (same for other outputs).
``` shell
$ peepdf -j /tmp/foo.pdf
{
    "peepdf_analysis": {
[...]
           "version": "0.3"
        }
    }
}
```
Given the object created by above call in local variable `content`:
```
<< /Length 131
/N 3
/Type /ObjStm
/Filter /FlateDecode
/First 14 >>
stream
x<9c>M<8c>[...]
endstream
```
at https://github.com/jbremer/peepdf/blob/11dab2ead9bf344e6aa8cca7f82a17771350f1be/peepdf/PDFCore.py#L7873 `self.charCounter` points to the end of the dictionary (`>>`) and is 65. `readUntilSymbol()` is supposed to advance it to the `stream` keyword which is three characters away. It first determines the substring to search based on the current value of `65`, then resets the counter to zero, finds the symbol three characters into the string and finally sets `self.charCounter` to `3`. The following calls to `readSymbol()` and colleagues fail silently but advance `charCounter` beyond the next newline. From there the next call to `readUntilSymbol('endstream')` tries to extract the actual objectstream content. Because `charCounter` is still in the middle of the dictionary, it extracts part of that as well and decoding of the object stream eventually fails.

Some poor man's debug prints showcase the issue:
```
diff --git a/peepdf/PDFCore.py b/peepdf/PDFCore.py
index a61d776..fc9df3b 100644
--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -7870,18 +7870,22 @@ class PDFParser:
                     nonDictContent = content[self.charCounter:]
                     streamFound = re.findall('[>\s]stream', nonDictContent)
                     if streamFound:
+                        print("1 charCounter: %d" % self.charCounter)
                         ret = self.readUntilSymbol(content, 'stream')
                         if ret[0] == -1:
                             return ret
+                        print("2 charCounter: %d, RET: %s" % (self.charCounter, ret[1]))
                         self.readSymbol(content, 'stream', False)
                         self.readUntilEndOfLine(content)
                         self.readSymbol(content, '\r', False)
                         self.readSymbol(content, '\n', False)
+                        print("3 charCounter: %d" % self.charCounter)
                         ret = self.readUntilSymbol(content, 'endstream')
                         if ret[0] == -1:
                             stream = content[self.charCounter:]
                         else:
                             stream = ret[1]
+                            print("4 charCounter: %d, RET: %s" % (self.charCounter, ret[1]))
                             self.readSymbol(content, 'endstream')
                         ret = self.createPDFStream(dictContent, stream)
                         if ret[0] == -1:
```
Output without the fix:
```
peepdf -j /tmp/foo.pdf
1 charCounter: 65
2 charCounter: 3, RET: >>

3 charCounter: 15
4 charCounter: 192, RET: /N 3
/Type /ObjStm
/Filter /FlateDecode
/First 14 >>
stream
x<9c>M<8c>[...]

Error: An error has occurred while parsing an indirect object!!
```
Output with the fix:
```
peepdf -j /tmp/foo.pdf
1 charCounter: 65
2 charCounter: 68, RET: >>

3 charCounter: 75
4 charCounter: 207, RET: x<9c>M<8c>[...]
```